### PR TITLE
Embed training GIF with explicit dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project implements a Deep Q-Network (DQN) agent to solve the CartPole environment from OpenAI Gym. The goal is to balance a pole on a moving cart by applying reinforcement learning techniques.
 
+<img src="training.gif" width="600" height="400" alt="CartPole training demo">
+
 ## Features
 
 - Implementation of a DQN agent using PyTorch.


### PR DESCRIPTION
## Summary
- embed training animation in README with HTML image tag and explicit 600x400 size

## Testing
- `pytest`
- Verified Markdown via GitHub API retains `<img>` tag with specified width and height

------
https://chatgpt.com/codex/tasks/task_e_688e8617405c8329bd12283a14d71801